### PR TITLE
* templates/container/docker/parts.tpl: We switched to 'container-' prefix now.

### DIFF
--- a/templates/container/docker/parts.tpl
+++ b/templates/container/docker/parts.tpl
@@ -107,7 +107,7 @@ ENTRYPOINT [{% for i in entry %}"{{ i }}"{% endfor %}]
 {%- macro footer() %}
 {%- set user = "" -%}
 {%- set entry = "" -%}
-{%- set cmd = "cont-start" -%}
+{%- set cmd = "container-start" -%}
 {%- if spec.parts.footer is defined %}
 {%- if spec.parts.footer.user is defined %}
 {%- set user = "USER " + spec.parts.footer.user %}


### PR DESCRIPTION
See https://github.com/sclorg/rhscl2dockerfile/pull/11