### PR TITLE
Implement --multispec-combinations, fix couple minor issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,7 @@ of that software. To make that easy, distgen provides a feature called
     
     matrix:
       exclude:
-        - distroinfo: fedora
-          distros:
+        - distros:
             - fedora-26-x86_64
           version: 2.2
     ```
@@ -139,7 +138,8 @@ behind this file):
 
 * `matrix` (optional) - currently, this attribute can only contain the
   `exclude` member. When used, the `exclude` attribute contains a list
-  of combinations excluded from the matrix.
+  of combinations excluded from the matrix. The `distroinfo` members
+  must be referred to via `distro` list.
 
 How multispec works:
 
@@ -181,6 +181,9 @@ Some notes on usage:
   multispec. In the example above, you can't use fedora-22\_i686, since
   it's not listed in any `distroinfo` section.
 * Combinations explicitly listed in `matrix.exclude` cannot be used.
+* You can use `dg --multispec <path> --multispec-combinations` to print out
+  all available combinations of distros and selectors based on the
+  given multispec file.
 
 Multispec mainly solves two problems:
 

--- a/bin/dg
+++ b/bin/dg
@@ -9,6 +9,7 @@ import shutil
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from distgen.generator import Generator
 from distgen.commands import CommandsConfig
+from distgen.multispec import Multispec
 
 def error(msg):
     print(msg, file=sys.stderr)
@@ -49,14 +50,6 @@ def parse_args():
         type=str,
         help='Use distribution metadata specified by DIST yaml file',
         default="fedora-21-x86_64.yaml",
-    )
-
-    parser.add_argument(
-        '--template',
-        metavar='TEMPLATE',
-        type=str,
-        help='Use TEMPLATE file, e.g. docker.tpl or a template string, '
-        'e.g. "{{ config.docker.from }}"'
     )
 
     parser.add_argument(
@@ -113,21 +106,34 @@ def parse_args():
         help='Define distgen\'s macro',
     )
 
+    tpl_or_combinations = parser.add_mutually_exclusive_group(required=True)
+
+    tpl_or_combinations.add_argument(
+        '--template',
+        metavar='TEMPLATE',
+        type=str,
+        help='Use TEMPLATE file, e.g. docker.tpl or a template string, '
+        'e.g. "{{ config.docker.from }}"'
+    )
+
+    tpl_or_combinations.add_argument(
+        '--multispec-combinations',
+        action='store_true',
+        help='Print available multispec combinations',
+    )
+
     return parser.parse_args()
 
 
-def main():
-    args = parse_args()
+def print_multispec_combinations(args):
+    ms = Multispec.from_path(args.projectdir, args.multispec)
+    for c in ms.get_all_combinations():
+        to_print = ['--distro {0}'.format(c.pop('distro'))]
+        [to_print.append('--multispec-selector {0}={1}'.format(k, v)) for k, v in c.items()]
+        print(' '.join(to_print))
 
-    required_opt_fail = False
-    for i in ["template"]:
-        if not getattr(args, i):
-            error("you must specify --" + i)
-            required_opt_fail = True
 
-    if required_opt_fail:
-        return 1
-
+def render_template(args):
     temp_filename = False
     output = sys.stdout
     try:
@@ -136,7 +142,6 @@ def main():
             output = open(temp_filename, 'w')
     except:
         die("can't create temporary file for '{0}'".format(args.output))
-
 
     cmd_cfg = CommandsConfig()
     cmd_cfg.container = args.container
@@ -170,6 +175,14 @@ def main():
             shutil.move(temp_filename, args.output)
         except:
             die("can't move '{0}' into '{1}'".format(temp_filename, args.output))
+
+
+def main():
+    args = parse_args()
+    if args.multispec_combinations:
+        print_multispec_combinations(args)
+    else:
+        render_template(args)
 
 
 if __name__ == "__main__":

--- a/distgen/generator.py
+++ b/distgen/generator.py
@@ -228,16 +228,8 @@ class Generator(object):
             except yaml.YAMLError, exc:
                 fatal("Error in spec file: {0}".format(exc))
         if multispec:
-            multispecfd = self.pm_spc.open_file(
-                multispec,
-                [self.project.directory],
-                fail=True,
-            )
-            if not multispecfd:
-                fatal("Multispec file {0} not found".format(multispec))
             try:
-                multispecdata = yaml.load(multispecfd)
-                mltspc = Multispec(multispecdata)
+                mltspc = Multispec.from_path(self.project.directory, multispec)
                 spec = merge_yaml(spec, mltspc.select_data(multispec_selectors, config))
             except yaml.YAMLError as exc:
                 fatal("Error in multispec file: {0}".format(exc))

--- a/tests/multispec/multispec.yaml
+++ b/tests/multispec/multispec.yaml
@@ -23,7 +23,6 @@ specs:
 
 matrix:
   exclude:
-    - distroinfo: fedora
-      distros:
+    - distros:
         - fedora-26-x86_64
       version: 2.2


### PR DESCRIPTION
This PR enables distgen to print out all allowed combinations based on a multispec file, example output:

```
--distro centos-7-x86_64 --multispec-selector version=2.2
--distro centos-7-x86_64 --multispec-selector version=2.4
--distro fedora-26-x86_64 --multispec-selector version=2.4
--distro fedora-25-x86_64 --multispec-selector version=2.2
--distro fedora-25-x86_64 --multispec-selector version=2.4
```

The output intentionally looks like something we might pass to `dg` command itself, I believe that it's more useful that way.