### PR TITLE
Fix multispec selector

### DIFF
--- a/bin/dg
+++ b/bin/dg
@@ -65,6 +65,7 @@ def parse_args():
         type=str,
         help='Selectors for the multispec file',
         action='append',
+        default=[],
     )
 
     parser.add_argument(

--- a/distgen/multispec.py
+++ b/distgen/multispec.py
@@ -177,6 +177,10 @@ class Multispec(object):
                 return False, '"{0}" not an entry in specs.{1}'.format(
                     selector_val, selector_name)
 
+        for selector_name in self.raw_data['specs'].keys():
+            if selector_name != DISTROINFO_GRP and selector_name not in parsed_selectors:
+                return False, '"{0}" selector must be present'.format(selector_name)
+
         # second, verify that these selector values are not excluded by matrix
         for excluded in self._matrix.get('exclude', []):
             exclude = True

--- a/tests/unittests/test_multispec.py
+++ b/tests/unittests/test_multispec.py
@@ -101,6 +101,7 @@ class TestMultispec(object):
     @pytest.mark.parametrize('selectors, distro, msg', [
         (['distroinfo=fedora'], 'fedora-26-x86_64', '"distroinfo" not allowed in selectors, it is '
          'chosen automatically based on distro'),
+        (['version=2.2'], 'fedora-26-x86_64', '"something_else" selector must be present'),
         (['xxx=asd'], 'fedora-26-x86_64', '"xxx" not an entry in specs'),
         (['version=3.4'], 'fedora-26-x86_64', '"3.4" not an entry in specs.version'),
         (['version=2.2', 'something_else=foo'], 'fedora-26-x86_64', 'This combination is excluded '


### PR DESCRIPTION
This PR fixes two issues with multispec selectors:
- Situation where we only have the `distroinfo` spec group, thus there are no selectors (in this case, the multispec selectors must be empty list, not `None`)
- Situation where not all required multispec selectors were used on invocation (in this case, we now print a nice error message without traceback)