### PR TITLE
use fedora base image from Fedora registry

### DIFF
--- a/distconf/lib/fedora.yaml
+++ b/distconf/lib/fedora.yaml
@@ -11,3 +11,4 @@ os:
 
 docker:
   from: fedora
+  registry: registry.fedoraproject.org

--- a/tests/docker-labels/test.exp
+++ b/tests/docker-labels/test.exp
@@ -1,6 +1,6 @@
 === fedora-21-x86_64 ===
 
-FROM index.docker.io/fedora:21
+FROM registry.fedoraproject.org/fedora:21
 MAINTAINER unknown <unknown@unknown.com>
 
 ENV container="docker"
@@ -13,7 +13,7 @@ CMD ["container-start"]
 
 === fedora-22-x86_64 ===
 
-FROM index.docker.io/fedora:22
+FROM registry.fedoraproject.org/fedora:22
 MAINTAINER unknown <unknown@unknown.com>
 
 ENV container="docker"

--- a/tests/dockerfile/test.exp
+++ b/tests/dockerfile/test.exp
@@ -1,6 +1,6 @@
 === fedora-21-x86_64 ===
 
-FROM index.docker.io/fedora:21
+FROM registry.fedoraproject.org/fedora:21
 MAINTAINER Pavel Raiskup <praiskup@redhat.com>
 
 ENV container="docker" \
@@ -36,7 +36,7 @@ CMD ["container-start"]
 
 === fedora-23-x86_64 ===
 
-FROM index.docker.io/fedora:23
+FROM registry.fedoraproject.org/fedora:23
 MAINTAINER Pavel Raiskup <praiskup@redhat.com>
 
 ENV container="docker" \

--- a/tests/minimal-dockerfile/test.exp
+++ b/tests/minimal-dockerfile/test.exp
@@ -1,6 +1,6 @@
 === fedora-21-x86_64 ===
 
-FROM index.docker.io/fedora:21
+FROM registry.fedoraproject.org/fedora:21
 MAINTAINER unknown <unknown@unknown.com>
 
 ENV container="docker"
@@ -10,7 +10,7 @@ CMD ["container-start"]
 
 === fedora-22-x86_64 ===
 
-FROM index.docker.io/fedora:22
+FROM registry.fedoraproject.org/fedora:22
 MAINTAINER unknown <unknown@unknown.com>
 
 ENV container="docker"


### PR DESCRIPTION
this is Fedora policy for container review process

Signed-off-by: Tomas Tomecek <ttomecek@redhat.com>