### PR TITLE
RFC: Enable recursive rendering of templates

### DIFF
--- a/bin/dg
+++ b/bin/dg
@@ -107,6 +107,14 @@ def parse_args():
         help='Define distgen\'s macro',
     )
 
+    parser.add_argument(
+        '--max-passes',
+        metavar='PASSES',
+        type=int,
+        default=1,
+        help='Maximum number of rendering passes, defaults to 1 (== no re-rendering)',
+    )
+
     tpl_or_combinations = parser.add_mutually_exclusive_group(required=True)
 
     tpl_or_combinations.add_argument(
@@ -168,6 +176,7 @@ def render_template(args):
         output,
         args.macros_from,
         explicit_macros,
+        args.max_passes,
     )
 
     if temp_filename:

--- a/distgen/generator.py
+++ b/distgen/generator.py
@@ -163,6 +163,17 @@ class Generator(object):
 
         config['macros'] = {x: merged[x] for x in macros.keys()}
 
+    def _recursive_render(self, tpl, max_passes=100, **kwargs):
+        rendered = tpl.render(**kwargs)
+
+        for i in range(0, max_passes):
+            new = jinja2.Template(rendered).render(**kwargs)
+            if new == rendered:
+                break
+            else:
+                rendered = new
+
+        return rendered
 
     def render(self, specfiles, multispec, multispec_selectors, template,
                config, cmd_cfg, output=sys.stdout, confdirs=None,
@@ -241,7 +252,8 @@ class Generator(object):
 
         self.project.inst_finish(specfiles, template, sysconfig, spec)
 
-        output.write(tpl.render(
+        output.write(self._recursive_render(
+            tpl,
             config=sysconfig,
             macros=sysconfig["macros"],
             m=sysconfig["macros"],

--- a/distgen/generator.py
+++ b/distgen/generator.py
@@ -31,6 +31,7 @@ class Generator(object):
         )
 
         self.pm_spc = PathManager([])
+        self.jinjaenv_args = {'keep_trailing_newline': True}
 
 
     def load_project(self, project):
@@ -69,7 +70,7 @@ class Generator(object):
 
         self.project.tplgen = jinja2.Environment(
             loader=loader,
-            keep_trailing_newline=True,
+            **self.jinjaenv_args
         )
 
         self.project.abstract_initialize()
@@ -163,11 +164,12 @@ class Generator(object):
 
         config['macros'] = {x: merged[x] for x in macros.keys()}
 
-    def _recursive_render(self, tpl, max_passes=100, **kwargs):
+    def _recursive_render(self, tpl, max_passes=25, **kwargs):
         rendered = tpl.render(**kwargs)
 
-        for i in range(0, max_passes):
-            new = jinja2.Template(rendered).render(**kwargs)
+        # we use `max_passes - 1`, because first pass is above
+        for i in range(0, max_passes - 1):
+            new = jinja2.Template(rendered, **self.jinjaenv_args).render(**kwargs)
             if new == rendered:
                 break
             else:

--- a/distgen/generator.py
+++ b/distgen/generator.py
@@ -172,6 +172,8 @@ class Generator(object):
             new = jinja2.Template(rendered, **self.jinjaenv_args).render(**kwargs)
             if new == rendered:
                 break
+            elif i == max_passes - 2:
+                fatal('Maximum number of rendering passes reached but template still changing')
             else:
                 rendered = new
 
@@ -179,7 +181,7 @@ class Generator(object):
 
     def render(self, specfiles, multispec, multispec_selectors, template,
                config, cmd_cfg, output=sys.stdout, confdirs=None,
-               explicit_macros={}):
+               explicit_macros={}, max_passes=1):
         """ render single template """
         config_path = [self.project.directory] + self.pm_cfg.get_path()
         sysconfig = load_config(config_path, config)
@@ -256,6 +258,7 @@ class Generator(object):
 
         output.write(self._recursive_render(
             tpl,
+            max_passes=max_passes,
             config=sysconfig,
             macros=sysconfig["macros"],
             m=sysconfig["macros"],

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Welcome to distgen's documentation!
    spec_multispec
    builtins
    macros
+   rerendering
 
 
 Indices and tables

--- a/docs/rerendering.rst
+++ b/docs/rerendering.rst
@@ -1,0 +1,51 @@
+.. _rerendering:
+
+Recursive Rendering
+===================
+
+*Note: This is an experimental feature introduced in version 0.16. It is
+subject to change or removal in future versions. Use at your own risk.*
+
+Recursive rendering is a concept similar to :ref:`macros <macros>`, perhaps
+aimed at obsoleting it altogether one day. For now, both of these live side
+by side.
+
+The idea behind recursive rendering is simple:
+
+* The template is rendered recursively until it stops changing.
+* Spec values can contain references to other spec or config values.
+  
+Note two things:
+
+* Maximum number of rendering passes is always limited to a reasonably
+  small integer (currently passed via ``--max-passes X`` on command line)
+  to make sure the re-rendering loop ends.
+* Recursive rendering is currently turned off, as ``--max-passes`` is
+  set to ``1``.
+
+Example
+-------
+
+Let's consider the following spec::
+
+    name: "myname"
+    help: "This is a help for {{ config.os.id }}/{{ spec.myname }} image."
+
+Let's try rendering a very simple template that looks like this::
+
+    {{ spec.help }}
+
+* In the first rendering pass, ``{{ spec.help }}`` will get substitued.
+* In the second rendering pass, ``{{ config.os.id }}`` and
+  ``{{ spec.myname }}`` will get substitued.
+* The third rendering pass will find out that there are no changes and
+  will end recursive rendering (so 3 passes are necessary).
+
+Usage
+-----
+
+As of now, recursive rendering is turned off by default (in other words,
+there's just one rendering pass). To turn it on, pass a number higher than
+2 to ``dg``'s ``--max-passes`` commandline switch. For example::
+
+    dg --distro fedora-26-x86_64.yaml --spec myspec.yaml --template Dockerfile --max-passes 10

--- a/tests/unittests/test_generator.py
+++ b/tests/unittests/test_generator.py
@@ -41,11 +41,16 @@ class TestGenerator(object):
         self.g.vars_fill_variables(config, sysconfig)
         assert config == result
 
-    @pytest.mark.parametrize('template, result', [
-        (os.path.join(simple, 'Dockerfile'), open(os.path.join(simple, 'expected_output')).read()),
-        ('{{ config.os.id }}', 'fedora'),
+    @pytest.mark.parametrize('template, max_passes, result', [
+        (os.path.join(simple, 'Dockerfile'), 1,
+         open(os.path.join(simple, 'expected_output')).read()),
+        (os.path.join(simple, 'Dockerfile'), 10, # should be the same no matter how many passes
+         open(os.path.join(simple, 'expected_output')).read()),
+        ('{{ config.os.id }}', 1, 'fedora'),
+        ("{{ '{{ config.os.id }}' }}", 1, '{{ config.os.id }}'),
+        ("{{ '{{ config.os.id }}' }}", 3, 'fedora'),
     ])
-    def test_render(self, template, result):
+    def test_render(self, template, max_passes, result):
         # TODO: more test cases for rendering
         self.g.load_project(simple)
         out = six.StringIO()
@@ -57,6 +62,7 @@ class TestGenerator(object):
             'fedora-26-x86_64.yaml',
             CommandsConfig(),
             out,
+            max_passes=max_passes,
         )
 
         if six.PY2:

--- a/tests/unittests/test_generator.py
+++ b/tests/unittests/test_generator.py
@@ -59,4 +59,6 @@ class TestGenerator(object):
             out,
         )
 
+        if six.PY2:
+            result = result.decode('utf-8')
         assert out.getvalue() == result


### PR DESCRIPTION
So I was thinking about the role that macros play and that it could be useful to have all values reexpanded like macros - e.g. [1], where it'd be ideal to create a `spec.image_name` value based on `{{ config.docker.from }}` or perhaps some other values.

Then I realized that we could actually achieve that with using templated values in both specs and configs and re-render the template recursively while it changes. So we could have e.g. spec which would say:

```
name: "myname"
help: "This is a help for {{ config.os.id }}/{{ spec.myname }} image."
```

and it would get expanded while rendering and re-rendering the template. I'm attaching a simple POC that achieves that. I believe it's much simpler than the macros mechanism and could one day replace that altogether (although for now I'd rather keep both mechanism alongside and just mark the macros mechanism obsolete in docs). I intentionally limited the number of recursive renderings, since this might lead infinite recursion in a while loop (if you folks like it, I'll make it nicer, include error messages etc).

CC @praiskup @TomasTomecek - WDYT?

[1] https://github.com/container-images/tools/pull/4/files#r139161677