### PR TITLE
Use jinja2's trim_blocks and lstrip_blocks

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include dg
 include requirements.txt
 include LICENSE
 include Makefile
+include NEWS
 include tests/testsuite
 include distconf/lib/*.yaml
 include distconf/*.yaml

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,68 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+New in 1.0:
+
+* Incompatible changes
+
+  - The 'trim_blocks' and 'lstrip_blocks' jinja2 options are enabled by
+    default for more convenient white-space maintenance.  The macros blocks
+    (conditions, loops, etc.) can look like '{% .. %}' instead of '{%- -%}'
+    in most cases.  This might require updating the templates (if
+    whitespaces matters) or using --keep-block-whitespaces to use the
+    old behavior.
+
+* New features
+
+  - Added option '--version'.
+
+  - Added 'centos-6-x86_64' dist config.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+New in 0.20:
+
+* New features
+
+  - Recursive re-rendering is done only for specs, not for the whole
+    template (performance, step towards having a library), PR#64.
+
+  - Recursive re-rendering is enabled by default, with default 32 passes.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+New in 0.19:
+
+  - Template files can be specified also with relative path.
+
+  - Files created through '--output' option are created according to the
+    umask setup.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+New in 0.18:
+
+* Bugfixes
+
+  - Lint fixes.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+New in 0.17:
+
+* New features
+
+  - Started shipping 'dg.1' manual page.
+
+* Bugfixes
+
+  - Distconf update for docker registries.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+New in 0.16:
+
+* New features
+
+  - recursive re-rendering, disabled by default (PR#41)
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/bin/dg
+++ b/bin/dg
@@ -130,6 +130,12 @@ parser.add_argument(
     help='Maximum number of rendering passes, defaults to 32',
 )
 
+parser.add_argument(
+    '--keep-block-whitespaces',
+    help="Disable the jinja2 trim_blocks and lstrip_blocks options",
+    action="store_true",
+)
+
 tpl_or_combinations = parser.add_mutually_exclusive_group(required=True)
 
 tpl_or_combinations.add_argument(
@@ -179,7 +185,14 @@ def render_template(args):
     if args.template == '-':
         args.template = "/proc/self/fd/0"
 
-    generator = Generator()
+    global_jinja_args = None
+    if not args.keep_block_whitespaces:
+        global_jinja_args = {
+            'trim_blocks': True,
+            'lstrip_blocks': True,
+        }
+
+    generator = Generator(global_jinja_args=global_jinja_args)
     generator.load_project(args.projectdir)
     generator.render(
         args.spec,

--- a/distgen/generator.py
+++ b/distgen/generator.py
@@ -20,7 +20,7 @@ class Generator(object):
     pm_tpl = None
     pm_spc = None
 
-    def __init__(self):
+    def __init__(self, global_jinja_args=None):
         self.pm_cfg = PathManager(
             [os.path.join(sys.prefix, "share", "distgen", "distconf")],
             envvar="DG_DISTCONFDIR"
@@ -33,6 +33,9 @@ class Generator(object):
 
         self.pm_spc = PathManager([])
         self.jinjaenv_args = {'keep_trailing_newline': True}
+
+        if global_jinja_args:
+            self.jinjaenv_args.update(global_jinja_args)
 
     def load_project(self, project):
         self.project = self._load_project_from_dir(project)

--- a/distgen/version.py
+++ b/distgen/version.py
@@ -1,1 +1,1 @@
-dg_version = "0.21.dev1"
+dg_version = "1.0.dev1"

--- a/rpm/distgen.spec
+++ b/rpm/distgen.spec
@@ -8,7 +8,7 @@
 
 Name:       distgen
 Summary:    Templating system/generator for distributions
-Version:    0.21%{?postrel:.%{postrel}%{posttag}}
+Version:    1.0%{?postrel:.%{postrel}%{posttag}}
 Release:    1%{?dist}
 Group:      Applications/Communications
 License:    GPLv2+
@@ -50,7 +50,7 @@ make PYTHON=%{pybin} check
 
 %files
 %license LICENSE
-%doc AUTHORS
+%doc AUTHORS NEWS
 %doc docs/
 %{_bindir}/dg
 %{pylib}/distgen
@@ -60,6 +60,9 @@ make PYTHON=%{pybin} check
 
 
 %changelog
+* Wed Mar 07 2018 Pavel Raiskup <praiskup@redhat.com> - 1.0.dev1-1
+- bump v1.0
+
 * Tue Oct 17 2017 Slavek Kabrda <bkabrda@redhat.com> - 0.18.dev1-1
 - update to 0.18.dev1
 

--- a/templates/container/docker/parts.tpl
+++ b/templates/container/docker/parts.tpl
@@ -1,137 +1,139 @@
-{%- macro header() -%}
+{% macro header() %}
 FROM {{ config.docker.registry + "/" + config.docker.from }}
 MAINTAINER {% if spec.maintainer %}{{ spec.maintainer }}{% else %}{{ project.maintainer }}{% endif %}
-{% endmacro -%}
+{% endmacro %}
 
-{%- macro expose() -%}
-{% if spec.expose is defined -%}
+{% macro expose() %}
+{% if spec.expose is defined %}
+
 EXPOSE {{ spec.expose | join(' ') }}
-
-{% endif -%}
-{%- endmacro -%}
-
-{%- macro variables(envs, type) -%}
-{%- if envs -%}
-{%- for i in envs -%}
-{%- if loop.first %}
-{{ type }} {{ i.name }}="{{ i.value | replace('"', '\\"') }}"
-{%- else %} \
-    {{ i.name }}="{{ i.value | replace('"', '\\"') }}"
-{%- endif -%}
-{%- endfor -%}
-{%- endif %}
-{% endmacro -%}
-
-{%- macro body_env() -%}
-{%- set vars = [] -%}
-{%- if container.name == "docker" -%}
-{%-   set vars = vars + [{'name': 'container', 'value': 'docker'}] -%}
-{%- endif -%}
-{%- if spec.parts is defined and  spec.parts.envvars is defined  -%}
-{%-   set vars = vars + spec.parts.envvars.data -%}
-{%- endif -%}
-{{- variables(vars, 'ENV') }}
-{%- endmacro -%}
-
-{%- macro body_labels() -%}
-{%- if spec.parts is defined and  spec.parts.labels is defined  -%}
-{{- variables(spec.parts.labels.data, 'LABEL') }}
-{%- endif -%}
-{%- endmacro -%}
-
-{%- macro execute(actions) -%}
-{%- for i in actions -%}
-{%- if loop.first %}
-RUN {{ command(i) }}{% else %} \
-    && {{ command(i) -}}
-{%- endif -%}
-{%- endfor -%}
-{% endmacro -%}
-
-{%- macro body_pkginstall() -%}
-{% if spec.parts.pkginstall is defined and spec.parts.pkginstall.data is defined %}
-{%- set cmds = spec.parts.pkginstall.data -%}
-{%- set cmds = cmds + [{"type": "pkg", "action": "cleancache"}] -%}
-{{ execute(cmds) }}
-{% endif -%}
-{% endmacro -%}
-
-{%- macro body_commands() -%}
-{%- if spec.parts.commands is defined and spec.parts.commands.data is defined -%}
-{{ execute(spec.parts.commands.data) }}
-{% endif -%}
-{% endmacro -%}
-
-{%- macro body_volumes() -%}
-{%- if spec.parts.volumes is defined %}
-VOLUME
-{%- for i in spec.parts.volumes.data %} \
-    "{{ i.path }}"{% endfor %}
 {% endif %}
-{%- endmacro -%}
+{% endmacro %}
+
+{% macro variables(envs, type) %}
+{% if envs %}
+{% for i in envs %}
+{% if loop.first %}{{ type }} {{ i.name }}="{{ i.value | replace('"', '\\"') }}"{% else %} \
+    {{ i.name }}="{{ i.value | replace('"', '\\"') }}"{% endif %}
+{% endfor %}
+{% endif %}
+{% endmacro %}
+
+{% macro body_env() %}
+{% set vars = [] %}
+{% if container.name == "docker" %}
+{%   set vars = vars + [{'name': 'container', 'value': 'docker'}] %}
+{% endif %}
+{% if spec.parts is defined and  spec.parts.envvars is defined  %}
+{%   set vars = vars + spec.parts.envvars.data %}
+{% endif %}
+{{ variables(vars, 'ENV') }}
+{% endmacro %}
+
+{% macro body_labels() %}
+{% if spec.parts is defined and  spec.parts.labels is defined  %}
+
+{{ variables(spec.parts.labels.data, 'LABEL') }}
+{% endif %}
+{% endmacro %}
+
+{% macro execute(actions) %}
+{% for i in actions %}
+{% if loop.first %}
+
+RUN {{ command(i) }}{% else %} \
+    && {{ command(i) }}{% endif %}
+{% endfor %}
+{% endmacro %}
+
+{% macro body_pkginstall() %}
+{% if spec.parts.pkginstall is defined and spec.parts.pkginstall.data is defined %}
+{% set cmds = spec.parts.pkginstall.data %}
+{% set cmds = cmds + [{"type": "pkg", "action": "cleancache"}] %}
+{{ execute(cmds) }}
+{% endif %}
+{% endmacro %}
+
+{% macro body_commands() %}
+{% if spec.parts.commands is defined and spec.parts.commands.data is defined %}
+{{ execute(spec.parts.commands.data) }}
+{% endif %}
+{% endmacro %}
+
+{% macro body_volumes() %}
+{% if spec.parts.volumes is defined %}
+
+VOLUME \
+{% for i in spec.parts.volumes.data %}
+{% if loop.last %}
+    "{{ i.path }}"
+{% else %}
+    "{{ i.path }}" \
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endmacro %}
 
 
-{%- macro add_tarball(file, dest="/") %}
-ADD "{{ file }}" "{{ dest -}}"
-{% endmacro -%}
+{% macro add_tarball(file, dest="/") %}
+
+ADD "{{ file }}" "{{ dest }}"
+{% endmacro %}
 
 
-{%- macro add_files(files) -%}
-{%- if files.files is defined -%}
-{%- for i in files.files -%}
-{%- if loop.first %}
-ADD "{{ i }}"{%- else %} \
-    "{{ i }}"
-{%- endif -%}
-{%- endfor %} \
+{% macro add_files(files) %}
+{% if files.files is defined %}
+{% for i in files.files %}
+{% if loop.first %}
+
+ADD "{{ i }}"{% else %} \
+    "{{ i }}"{% endif %}
+{% endfor %} \
     "{{ files.dest }}"
-{%- endif %}
+{% endif %}
 {% endmacro %}
 
 
-{% macro body_addfiles() -%}
-{%- if spec.parts.addfiles is defined and spec.parts.addfiles.data is defined -%}
-{%- set files = spec.parts.addfiles.data -%}
-{%- for i in files -%}
-{%- if i.type == "files" -%}
-{{ add_files(i) }}
-{%- elif i.type == "tarball" -%}
-{{ add_tarball(i.file) }}
-{%- endif -%}
-{%- endfor -%}
-{%- endif -%}
+{% macro body_addfiles() %}
+{% if spec.parts.addfiles is defined and spec.parts.addfiles.data is defined %}
+{% set files = spec.parts.addfiles.data %}
+{% for i in files %}
+{% if i.type == "files" %}
+{{ add_files(i) -}}
+{% elif i.type == "tarball" %}
+{{ add_tarball(i.file) -}}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endmacro %}
 
-{% macro cmd_footer(what, array) -%}
+{% macro cmd_footer(what, array) %}
 {{ what }} [
-{%- for i in array -%}
-{%- if loop.last -%}
-"{{ i }}"
-{%- else -%}
-"{{ i }}", {% endif -%}
-{%- endfor -%}
+{%- for i in array %}
+{% if loop.last %}"{{ i }}"{% else %}"{{ i }}", {% endif %}
+{% endfor -%}
 ]
-{%- endmacro %}
+{% endmacro %}
 
-{%- macro footer() %}
-{%- set user = "" -%}
-{%- set entry = "" -%}
-{%- set cmd = ["container-start"] -%}
-{%- if spec.parts is defined and spec.parts.footer is defined %}
-{%- if spec.parts.footer.user is defined %}
-{%- set user = "USER " + spec.parts.footer.user %}
-{%- endif -%}
-{%- if spec.parts.footer.cmd is defined %}
-{%- set cmd = spec.parts.footer.cmd -%}
-{%- endif -%}
-{%- endif %}
-{{ expose() -}}
+{% macro footer() %}
+{% set user = "" %}
+{% set entry = "" %}
+{% set cmd = ["container-start"] %}
+{% if spec.parts is defined and spec.parts.footer is defined %}
+{% if spec.parts.footer.user is defined %}
+{% set user = "USER " + spec.parts.footer.user %}
+{% endif %}
+{% if spec.parts.footer.cmd is defined %}
+{% set cmd = spec.parts.footer.cmd %}
+{% endif %}
+{% endif %}
+{{ expose() }}
 {% if user %}{{ user }}
-{% endif -%}
-{%- if spec.parts is defined and spec.parts.footer is defined and spec.parts.footer.entry is defined -%}
-{{- cmd_footer("ENTRYPOINT", spec.parts.footer.entry) }}
-{% endif -%}
-{%- if cmd %}
-{{- cmd_footer("CMD", cmd) }}
-{%- endif -%}
-{%- endmacro -%}
+{% endif %}
+{% if spec.parts is defined and spec.parts.footer is defined and spec.parts.footer.entry is defined %}
+{{ cmd_footer("ENTRYPOINT", spec.parts.footer.entry) -}}
+{% endif %}
+{% if cmd %}
+{{ cmd_footer("CMD", cmd) -}}
+{% endif %}
+{% endmacro %}

--- a/templates/docker.tpl
+++ b/templates/docker.tpl
@@ -1,23 +1,23 @@
-{%- extends "general.tpl" -%}
+{% extends "general.tpl" %}
 
-{%- block content -%}
-{%-   block header -%}
-{{      ctr.header() }}
-{%-   endblock %}
+{% block content %}
+  {% block header %}
+{{ ctr.header() }}
+  {%   endblock %}
 
-{%-   block body -%}
-{%-     block pkginstall -%}
-{{-        ctr.body_env() -}}
-{{-        ctr.body_labels() -}}
-{%- if spec.parts is defined -%}
-{{-        ctr.body_pkginstall() -}}
-{{-        ctr.body_addfiles() -}}
-{{-        ctr.body_commands() -}}
-{{-        ctr.body_volumes() -}}
-{%- endif -%}
-{%-     endblock -%}
-{%-   endblock -%}
-{%-   block footer -%}
-{{-     ctr.footer() -}}
-{%-   endblock %}
+  {% block body %}
+    {% block pkginstall %}
+{{ ctr.body_env() + ctr.body_labels() -}}
+      {% if spec.parts is defined %}
+{{ ctr.body_pkginstall() +
+   ctr.body_addfiles() +
+   ctr.body_commands() +
+   ctr.body_volumes()
+-}}
+      {% endif %}
+    {% endblock %}
+  {% endblock %}
+  {% block footer %}
+{{ ctr.footer() -}}
+  {% endblock %}
 {% endblock %}

--- a/tests/keep-block-whitespaces/dg-opts
+++ b/tests/keep-block-whitespaces/dg-opts
@@ -1,0 +1,1 @@
+--keep-block-whitespaces

--- a/tests/keep-block-whitespaces/distros
+++ b/tests/keep-block-whitespaces/distros
@@ -1,0 +1,1 @@
+fedora-rawhide-x86_64

--- a/tests/keep-block-whitespaces/test.exp
+++ b/tests/keep-block-whitespaces/test.exp
@@ -1,0 +1,6 @@
+=== fedora-rawhide-x86_64 ===
+
+
+  
+
+shown

--- a/tests/keep-block-whitespaces/test.tpl
+++ b/tests/keep-block-whitespaces/test.tpl
@@ -1,0 +1,6 @@
+{% if True %}
+  {% if False %}
+not shown
+  {% endif %}
+{% endif %}
+shown

--- a/tests/testsuite
+++ b/tests/testsuite
@@ -18,6 +18,7 @@ tests="
     non-ascii-chars
     pkginstaller
     no-spec
+    keep-block-whitespaces
 "
 
 success=:


### PR DESCRIPTION
This makes the taking care of white-spaces much more intuitive,
because "minus" signs in blocks '{%- -%}' are not needed
(sometimes needed in '{{ -}}'.  The language is still complete but
see how the 'docker.tpl' template was simplified in this commit.

To revert to the previous behavior users can use
--keep-block-whitespaces option.