### PR TITLE
Unify error handling through err.py

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,8 @@ New in 1.0:
 
   - The --distro flag accepts arguments both with/without ".yaml" suffix.
 
+  - Error output is printed out consistently through fatal() to stderr.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 New in 0.20:

--- a/bin/dg
+++ b/bin/dg
@@ -11,18 +11,16 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 import six
 
+import logging
+logging.basicConfig(format='dg: %(levelname)-8s: %(message)s')
+
 from distgen.generator import Generator
 from distgen.commands import CommandsConfig
 from distgen.multispec import Multispec
 from distgen.version import dg_version
 from distgen.distro_version import detect_default_distro
+from distgen.err import fatal
 
-def error(msg):
-    print(msg, file=sys.stderr)
-
-def die(msg):
-    error(msg)
-    sys.exit(1)
 
 description = \
 """
@@ -172,7 +170,7 @@ def render_template(args):
             _, temp_filename = tempfile.mkstemp(prefix="distgen-")
             output = open(temp_filename, 'wb')
     except:
-        die("can't create temporary file for '{0}'".format(args.output))
+        fatal("can't create temporary file for '{0}'".format(args.output))
 
     cmd_cfg = CommandsConfig()
     cmd_cfg.container = args.container
@@ -226,7 +224,7 @@ def render_template(args):
             os.umask(umask)
             os.chmod(args.output, 0o666 &~umask)
         except:
-            die("can't move '{0}' into '{1}'".format(temp_filename, args.output))
+            fatal("can't move '{0}' into '{1}'".format(temp_filename, args.output))
 
 
 def main():

--- a/distgen/config.py
+++ b/distgen/config.py
@@ -1,7 +1,4 @@
-from __future__ import print_function
-
 import six
-import sys
 import copy
 
 from distgen.err import fatal
@@ -44,8 +41,7 @@ def __recursive_load(pm, stack, filename):
             file_desc="configuration file",
         ))
     except yaml.YAMLError as exc:
-        print("Error in configuration file: {0}".format(exc))
-        sys.exit(1)
+        fatal("Error in configuration file: {0}".format(exc))
 
     if yaml_data and "extends" in yaml_data:
         subdata = __recursive_load(pm, stack, yaml_data["extends"])

--- a/distgen/generator.py
+++ b/distgen/generator.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 import imp

--- a/distgen/pathmanager.py
+++ b/distgen/pathmanager.py
@@ -1,7 +1,6 @@
-from __future__ import print_function
-
 import os
-import sys
+
+from distgen.err import fatal
 
 
 class PathManager(object):
@@ -34,8 +33,7 @@ class PathManager(object):
                     return cf
 
         if fail:
-            print("can't find {0} '{1}'".format(file_desc, filename))
-            sys.exit(1)
+            fatal("can't find {0} '{1}'".format(file_desc, filename))
 
         return None
 
@@ -51,8 +49,7 @@ class PathManager(object):
             fd = open(filename)
         except IOError:
             if fail:
-                print("can't open file {0}".format(relative))
-                sys.exit(1)
+                fatal("can't open file {0}".format(relative))
             return None
 
         return fd


### PR DESCRIPTION
Previously we used print(), which even sometimes printed the error
output to stdout instead of to stderr.