### PR TITLE
rpm: use PyPI's predictable Source0 url

### DIFF
--- a/rpm/distgen.spec.dg
+++ b/rpm/distgen.spec.dg
@@ -19,7 +19,7 @@ Requires:      %both_requires
 BuildRequires: %{pypkg}-setuptools %{pypkg}-devel %{?fedora:%{pypkg}-}pytest %both_requires
 BuildRequires: %{pypkg}-pytest-catchlog %pypkg-mock
 
-Source0: https://github.com/devexp-db/distgen/archive/v%version/distgen-%version.tar.gz
+Source0: https://pypi.org/packages/source/d/%name/%name-%version.tar.gz
 
 %description
 Based on given template specification (configuration for template), template


### PR DESCRIPTION
That url is better than the archive/tag url provided by github
since this is uploaded tarball instead of on-demand generated (so
the tarball checksums should never change).  More, the github's
tarball doesn't include assigned git submodules, which is another
blocker for this project.

We could use GitHub's
https://github.com/devexp-db/distgen/releases/download/../..tar.gz
urls, but that requires (another) manual upload the tarball into
github storage.