### PR TITLE
New multispec feature: combination extras

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,10 @@ New in 1.2:
   - The distconf 'fedora-rawhide-x86_64' now uses value 'fedora:rawhide'
     for 'docker.from', instead of 'fedora:NN'.
 
+  - The 'combination_extras' member in matrix section of 'multipec' allow
+    to list extras, mapping of key-value pairs, which are only added to the
+    specific distro and version combination.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 New in 1.1:

--- a/docs/spec_multispec.rst
+++ b/docs/spec_multispec.rst
@@ -78,13 +78,20 @@ Here's an example multispec file::
        "2.4":
          version: "2.4"
    
-   # in the "matrix" section, you can specify combinations that you want
-   # to explicitly exclude from the rendering matrix
+   # in the "matrix" section, you can define an action that is
+   # applied only to specified distro and version combinations
    matrix:
      exclude:
        - distros:
            - fedora-26-x86_64
          version: "2.2"
+
+     combination_extras:
+       - distros:
+           - centos-7-x86_64
+         version: "2.4"
+         data:
+           extra_pkgs: ['foo', 'bar']
 
 A multispec has 3 attributes (see below for the explanation of mechanics
 behind this file):
@@ -104,10 +111,16 @@ behind this file):
     ``distroinfo`` *group* is an exception, as its members ``distros`` list
     are used in the cartesian product.
 
-* ``matrix`` (optional) - currently, this attribute can only contain the
-  ``exclude`` member. When used, the ``exclude`` attribute contains a list
-  of combinations excluded from the matrix. The ``distroinfo`` members
-  must be referred to via ``distro`` list.
+* ``matrix`` (optional) - currently, this attribute can only contain two
+  members.
+
+  * The ``exclude`` attribute contains a list of combinations excluded
+    from the matrix. The ``distroinfo`` members must be referred to via
+    ``distro`` list.
+  
+  * The ``combination_extras`` member contains a list of combinations and
+    extras, mapping of key-value pairs, which are only added to this combination
+    and can be used in your templates.
 
 Hence the above example produces a following rendering matrix:
 

--- a/tests/multispec/multispec.yaml
+++ b/tests/multispec/multispec.yaml
@@ -26,4 +26,16 @@ matrix:
   exclude:
     - distros:
         - fedora-26-x86_64
-      version: 2.2
+      version: "2.2"
+
+  combination_extras:
+    - distros:
+        - fedora-26-x86_64
+      version: "2.4"
+      data:
+        name_label: "$FGC/$NAME"
+    - distros:
+        - centos-7-x86_64
+      version: "2.2"
+      data:
+        name_label: "centos/SW-2.2-centos7"

--- a/tests/multispec/test.exp
+++ b/tests/multispec/test.exp
@@ -8,6 +8,7 @@ ENV NAME=mycontainer VERSION=0 RELEASE=1 ARCH=x86_64
 
 LABEL summary="A container that tells you how awesome it is." \
       com.redhat.component="$NAME" \
+      NAME="$FGC/$NAME" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
       architecture="$ARCH" \

--- a/tests/multispec/test.tpl
+++ b/tests/multispec/test.tpl
@@ -6,6 +6,9 @@ ENV NAME=mycontainer VERSION=0 RELEASE=1 ARCH=x86_64
 
 LABEL summary="A container that tells you how awesome it is." \
       com.redhat.component="$NAME" \
+      {% if spec.name_label %}
+      NAME="{{ spec.name_label }}" \
+      {% endif %}
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
       architecture="$ARCH" \

--- a/tests/unittests/fixtures/multispec/complex.yaml
+++ b/tests/unittests/fixtures/multispec/complex.yaml
@@ -39,3 +39,17 @@ matrix:
       version: "2.4"
       something_else: bar
 
+  combination_extras:
+    - distros:
+        - fedora-26-x86_64
+      version: "2.4"
+      data:
+        name_label: "$FGC/$NAME"
+        base_version: 1
+
+    - distros:
+        - centos-7-x86_64
+      version: "2.2"
+      data:
+        name_label: "centos/SW-2.2-centos7"
+

--- a/tests/unittests/test_multispec.py
+++ b/tests/unittests/test_multispec.py
@@ -89,6 +89,25 @@ class TestMultispec(object):
         with pytest.raises(MultispecError):
             ms.parse_selectors(['foo bar'])
 
+    @pytest.mark.parametrize('node, distro, selectors, expected', [
+        ('exclude', 'fedora-26-x86_64', ['version=2.2'], [True, False]),
+        ('exclude', 'fedora-26-x86_64', ['version=2.4'], [False, False]),
+        ('combination_extras', 'fedora-26-x86_64', ['version=2.4'],
+         [{'name_label': "$FGC/$NAME",
+           'base_version': 1}, False]),
+        ('combination_extras', 'fedora-26-x86_64', ['version=2.2'],
+         [False, False]),
+        ('combination_extras', 'centos-7-x86_64', ['version=2.2'],
+         [False, {'name_label': 'centos/SW-2.2-centos7'}]),
+    ])
+    def test_check_matrix_combinations(self, node, distro,
+                                       selectors, expected):
+        ms = Multispec.from_path(ms_fixtures, 'complex.yaml')
+        parsed_selectors = ms.parse_selectors(selectors)
+        assert list(ms.check_matrix_combinations(node,
+                                                 distro,
+                                                 parsed_selectors)) == expected
+
     def test_distrofile2name(self):
         ms = Multispec.from_path(ms_fixtures, 'simplest.yaml')
         assert ms.distrofile2name('foo/bar/fedora-26-x86_64.yaml') == 'fedora-26-x86_64'
@@ -120,7 +139,9 @@ class TestMultispec(object):
              'distro_specific_help': 'Some Fedora specific help',
              'spam': 'ham',
              'vendor': 'Fedora Project',
-             'version': '2.4'}
+             'version': '2.4',
+             'base_version': 1,
+             'name_label': '$FGC/$NAME'}
 
     def test_select_data_nok(self):
         ms = Multispec.from_path(ms_fixtures, 'complex.yaml')


### PR DESCRIPTION
When writing templates and specs for [s2i-python-container](https://github.com/sclorg/s2i-python-container) I found out there is a couple of problematic cases when some value is needed only for one combination of the matrix. I used [some workarounds](https://github.com/sclorg/s2i-python-container/blob/master/specs/multispec.yml#L19) to make it work for now, but It would be much nicer to have possibility to add some data only for the specific distro and version combination. 

This PR adds combination_extras member to the matrix section of multispec for this purpose.

Resolves https://github.com/devexp-db/distgen/issues/68.