### PR TITLE
 Add `{{ spec.multispec_raw }}` template namespace

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,9 @@ New in 1.3:
 
   - Compatibility fixes for new PyYAML 5.1.
 
+  - The '{{ spec.multispec_raw }}' template namespace added if distgen
+    is run with --multispec* options.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 New in 1.2:

--- a/distgen/generator.py
+++ b/distgen/generator.py
@@ -276,6 +276,7 @@ class Generator(object):
                 mltspc = Multispec.from_path(self.project.directory, multispec)
                 spec = merge_yaml(
                     spec, mltspc.select_data(multispec_selectors, config))
+                spec = merge_yaml(spec, {'multispec_raw': mltspc.raw()})
             except yaml.YAMLError as exc:
                 fatal("Error in multispec file: {0}".format(exc))
             except MultispecError as exc:

--- a/distgen/multispec.py
+++ b/distgen/multispec.py
@@ -283,3 +283,10 @@ class Multispec(object):
 
     def distrofile2name(self, distro):
         return os.path.splitext(os.path.basename(distro))[0]
+
+    def raw(self):
+        return {
+            'version': copy.deepcopy(self._version),
+            'matrix': copy.deepcopy(self._matrix),
+            'specs': copy.deepcopy(self._specgroups),
+        }

--- a/docs/spec_multispec.rst
+++ b/docs/spec_multispec.rst
@@ -159,6 +159,10 @@ On calling this command, distgen will:
 * Render the template providing the result of operations above accessible
   under ``spec.*`` values.
 
+* The template ``spec.multispec_raw`` namespace exists as well.  Under
+  this namespace temlpates can access the whole multispec matrix (not only
+  the selected slice).
+
 Notes on Multispec Usage
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/multispec-raw/distros
+++ b/tests/multispec-raw/distros
@@ -1,0 +1,3 @@
+fedora-26-x86_64
+centos-6-x86_64
+centos-7-x86_64

--- a/tests/multispec-raw/multispec.yaml
+++ b/tests/multispec-raw/multispec.yaml
@@ -1,0 +1,41 @@
+version: 1
+
+specs:
+  distroinfo:
+    fedora:
+      distros:
+        - fedora-26-x86_64
+        - fedora-25-x86_64
+      vendor: "Fedora Project"
+      authoritative_source_url: "some.url.fedoraproject.org"
+      distro_specific_help: "Some Fedora specific help"
+    centos:
+      distros:
+        - centos-6-x86_64
+        - centos-7-x86_64
+      vendor: "CentOS"
+      authoritative_source_url: "some.url.centos.org"
+      distro_specific_help: "Some CentOS specific help"
+  version:
+    "2.2":
+      version: 2.2
+    "2.4":
+      version: 2.4
+
+matrix:
+  exclude:
+    - distros:
+        - fedora-26-x86_64
+      version: "2.2"
+
+  combination_extras:
+    - distros:
+        - fedora-26-x86_64
+      version: "2.4"
+      data:
+        name_label: "$FGC/$NAME"
+    - distros:
+        - centos-7-x86_64
+      version: "2.2"
+      data:
+        name_label: "centos/SW-2.2-centos7"

--- a/tests/multispec-raw/test.exp
+++ b/tests/multispec-raw/test.exp
@@ -1,0 +1,13 @@
+=== fedora-26-x86_64 ===
+
+fedora-26-x86_64
+
+
+=== centos-6-x86_64 ===
+
+fedora-26-x86_64
+
+
+=== centos-7-x86_64 ===
+
+fedora-26-x86_64

--- a/tests/multispec-raw/test.tpl
+++ b/tests/multispec-raw/test.tpl
@@ -1,0 +1,1 @@
+{{ spec.multispec_raw.matrix.combination_extras[0].distros[0] }}

--- a/tests/multispec-raw/test.yaml
+++ b/tests/multispec-raw/test.yaml
@@ -1,0 +1,2 @@
+name: myawesomeimage
+description: "This is a simple container that just tells you how awesome it is. That's it."

--- a/tests/testsuite
+++ b/tests/testsuite
@@ -19,6 +19,7 @@ tests="
     pkginstaller
     no-spec
     keep-block-whitespaces
+    multispec-raw
 "
 
 success=:
@@ -141,7 +142,7 @@ for i in $tests; do
     }
 
     diff -ruN "$wd/test.exp" "$wd/test.out" > "$wd/test.diff" 2>> "$wd/test.err" \
-        || { fail "test '$i' failed (diff)'" ; continue ; }
+        || { fail "test '$i' failed (diff)'" ; cat "$wd/test.diff" ; continue ; }
 done
 
 output_equals_stdout


### PR DESCRIPTION

    
    It is sometimes convenient, even when we don't generate template
    for "multispec-selected" data - to be able to use the multispec
    matrix.  This is per ideas from sclorg/s2i-python-container#318.
