### PR TITLE
Handle PyYAML 5.1 Loader= warnings

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ New in 1.3:
 
   - Added 'fedora-30' config, and rawhide moved to 'fedora-31'.
 
+  - Compatibility fixes for new PyYAML 5.1.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 New in 1.2:

--- a/distgen/config.py
+++ b/distgen/config.py
@@ -35,11 +35,14 @@ def __recursive_load(pm, stack, filename):
 
     import yaml
     try:
-        yaml_data = yaml.load(pm.open_file(
-            filename,
-            fail=True,
-            file_desc="configuration file",
-        ))
+        yaml_data = yaml.load(
+            pm.open_file(
+                filename,
+                fail=True,
+                file_desc="configuration file",
+            ),
+            Loader=yaml.SafeLoader,
+        )
     except yaml.YAMLError as exc:
         fatal("Error in configuration file: {0}".format(exc))
 

--- a/distgen/multispec.py
+++ b/distgen/multispec.py
@@ -33,7 +33,7 @@ class Multispec(object):
     def from_path(cls, project_dir, path):
         pm = PathManager([])
         fd = pm.open_file(path, [project_dir], fail=True)
-        data = yaml.load(fd)
+        data = yaml.load(fd, Loader=yaml.SafeLoader)
         return cls(data)
 
     def _process(self):

--- a/tests/unittests/test_multispec.py
+++ b/tests/unittests/test_multispec.py
@@ -28,7 +28,7 @@ class TestMultispec(object):
 
     def test_validate(self):
         with open(os.path.join(ms_fixtures, 'complex.yaml')) as f:
-            Multispec(yaml.load(f))._validate()
+            Multispec(yaml.load(f, Loader=yaml.SafeLoader))._validate()
 
     def test_has_spec_group(self):
         ms = Multispec.from_path(ms_fixtures, 'complex.yaml')


### PR DESCRIPTION
    Fix PyYAML 5.1 Loader= warnings
    
    Per [1] upstream docs, we should use safe loader where we can.
    For parsing '!eval' we need full loader though.  So use Loaders
    appropriately.
    
    Slightly inconvenient is to write this thing portably because
    FullLoader isn't available in old PyYAML versions.
    
    [1] https://msg.pyyaml.org/load
