### PR TITLE
Fix Requires for Python YAML lib on RHEL-8

### DIFF
--- a/rpm/distgen.spec.dg
+++ b/rpm/distgen.spec.dg
@@ -23,7 +23,7 @@ BuildArch:  noarch
 
 Requires: %{pypkg}-jinja2
 Requires: %{pypkg}-distro
-Requires: %{?fedora:%{pypkg}-}PyYAML
+Requires: %{meh_pypkg}PyYAML
 Requires: %{pypkg}-six
 
 BuildRequires: %{pypkg}-devel


### PR DESCRIPTION
Both BuildRequires and Requires should be the same, without this, the installation fails with:
```
Error: 
 Problem: conflicting requests
  - nothing provides PyYAML needed by distgen-1.4-1.el8.noarch
```