### PR TITLE
distconf: re-define name for c9s

### DIFF
--- a/distgen/distconf/centos-stream-9-x86_64.yaml
+++ b/distgen/distconf/centos-stream-9-x86_64.yaml
@@ -1,6 +1,7 @@
 extends: "lib/centos.yaml"
 
 os:
+  name: CentOS Stream
   version: 9
   arch: x86_64
 


### PR DESCRIPTION
It's CentOS Stream, not just CentOS inherited from the lib/centos.yml.