### PR TITLE
Use unittests.mock instead of third-party mock

### DIFF
--- a/rpm/distgen.spec.dg
+++ b/rpm/distgen.spec.dg
@@ -30,9 +30,9 @@ BuildRequires: make
 BuildRequires: %{pypkg}-devel
 BuildRequires: %{pypkg}-distro
 BuildRequires: %{pypkg}-jinja2
-BuildRequires: %pypkg-mock
 BuildRequires: %{meh_pypkg}pytest
 %if 0%{?rhel} && 0%{?rhel} < 8
+BuildRequires: %{pypkg}-mock
 BuildRequires: %{pypkg}-pytest-catchlog
 %endif
 BuildRequires: %{meh_pypkg}PyYAML

--- a/tests/unittests/test_distro_detection.py
+++ b/tests/unittests/test_distro_detection.py
@@ -1,7 +1,9 @@
-import os
-import sys
 import pytest
-from mock import patch
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from distgen.distro_version import detect_default_distro
 


### PR DESCRIPTION
As long as it is available.  On EL7 we still use python2-mock.