### PR TITLE
Introduce centos-stream.yaml which differs from centos.yaml

### DIFF
--- a/distgen/distconf/centos-stream-9-x86_64.yaml
+++ b/distgen/distconf/centos-stream-9-x86_64.yaml
@@ -1,4 +1,4 @@
-extends: "lib/centos.yaml"
+extends: "lib/centos-stream.yaml"
 
 os:
   name: CentOS Stream

--- a/distgen/distconf/lib/centos-stream.yaml
+++ b/distgen/distconf/lib/centos-stream.yaml
@@ -6,4 +6,4 @@ os:
 
 docker:
   registry: quay.io/centos
-  from: centos:stream9
+  from: centos

--- a/distgen/distconf/lib/centos-stream.yaml
+++ b/distgen/distconf/lib/centos-stream.yaml
@@ -1,0 +1,9 @@
+extends: lib/rpmsystems.yaml
+
+os:
+  id: centos-stream
+  name: CentOS Stream Linux
+
+docker:
+  registry: quay.io/centos
+  from: centos:stream9


### PR DESCRIPTION
Our container uses this directive https://github.com/sclorg/s2i-python-container/blob/master/src/Dockerfile.template#L2
In order to separate 'centos' from 'centos-stream-9' this change would help us.

@frenzymadness What do you think about this change?

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>