### PR TITLE
add pypi-publish github action

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,34 @@
+# MIT License
+#
+# Copyright (c) 2022 sclorg team at Red Hat
+#
+# Upload a Python package when a release is created
+# https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows
+
+name: Publish Python 🐍 distributions 📦 to PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+      - name: Build a source tarball and a binary wheel
+        # https://pypa-build.readthedocs.io
+        run: |
+          python -m pip install -r requirements.txt
+          python setup.py sdist
+
+      - name: Publish 📦 to PyPI
+        # https://github.com/pypa/gh-action-pypi-publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # secrets.PYPI_API_TOKEN is set to usercont-release-bot user token
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          verbose: true


### PR DESCRIPTION
Note: `PYPI_API_TOKEN` has to be added to repository secrets, before merging (it seems, that I do not have rights for generating it.)

This action automatically publishes release on pypi, when created

Source of the code: https://github.com/sclorg/container-workflow-tool/