### PR TITLE
distconf: add support rhel-9-x86_64 config

### DIFF
--- a/distgen/distconf/rhel-9-x86_64.yaml
+++ b/distgen/distconf/rhel-9-x86_64.yaml
@@ -1,0 +1,7 @@
+extends: "rhel-7-x86_64.yaml"
+
+os:
+  version: 9
+
+docker:
+  from: rhel9

--- a/tests/minimal-dockerfile/distros
+++ b/tests/minimal-dockerfile/distros
@@ -2,3 +2,4 @@ fedora-21-x86_64
 fedora-22-x86_64
 rhel-7-x86_64
 rhel-8-x86_64
+rhel-9-x86_64

--- a/tests/minimal-dockerfile/test.exp
+++ b/tests/minimal-dockerfile/test.exp
@@ -36,3 +36,13 @@ MAINTAINER unknown <unknown@unknown.com>
 ENV container="docker"
 
 CMD ["container-start"]
+
+
+=== rhel-9-x86_64 ===
+
+FROM registry.access.redhat.com/rhel9
+MAINTAINER unknown <unknown@unknown.com>
+
+ENV container="docker"
+
+CMD ["container-start"]


### PR DESCRIPTION
This pull request adds support for RHEL-9 generation sources.