### PR TITLE
Add `include` to multispec matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON = `which python2`
+PYTHON = `which python3`
 
 all:
 	@echo no build make rule yet, just '"make check"'

--- a/dg
+++ b/dg
@@ -2,7 +2,7 @@
 
 proj_cli_dir="$(dirname "$(readlink -f "$0")")"
 
-export PYTHON=${PYTHON:-`which python2`}
+export PYTHON=${PYTHON:-`which python3`}
 export PYTHONPATH="$proj_cli_dir${PYTHONPATH+:$PYTHONPATH}"
 
 $PYTHON $proj_cli_dir/bin/dg "$@"

--- a/distgen/multispec.py
+++ b/distgen/multispec.py
@@ -107,6 +107,7 @@ class Multispec(object):
                 'matrix must be a mapping, is "{0}"'.format(type(matrix)))
 
         self._validate_matrix_node('exclude', matrix)
+        self._validate_matrix_node('include', matrix)
         self._validate_matrix_node('combination_extras', matrix)
 
     def _validate_matrix_node(self, node_name, matrix):

--- a/docs/spec_multispec.rst
+++ b/docs/spec_multispec.rst
@@ -111,13 +111,19 @@ behind this file):
     ``distroinfo`` *group* is an exception, as its members ``distros`` list
     are used in the cartesian product.
 
-* ``matrix`` (optional) - currently, this attribute can only contain two
+* ``matrix`` (optional) - currently, this attribute can only contain three
   members.
 
   * The ``exclude`` attribute contains a list of combinations excluded
     from the matrix. The ``distroinfo`` members must be referred to via
     ``distro`` list.
+
+  * The ``include`` attribute contains a list of combinations included
+    from the matrix. The ``distroinfo`` members must be referred to via
+    ``distro`` list.
   
+  ``exclude`` and ``include`` are mutually exclusive.
+
   * The ``combination_extras`` member contains a list of combinations and
     extras, mapping of key-value pairs, which are only added to this combination
     and can be used in your templates.

--- a/tests/multispec-include/distros
+++ b/tests/multispec-include/distros
@@ -1,0 +1,2 @@
+fedora-26-x86_64
+centos-7-x86_64

--- a/tests/multispec-include/multispec.yaml
+++ b/tests/multispec-include/multispec.yaml
@@ -1,0 +1,42 @@
+version: 1
+
+specs:
+  distroinfo:
+    fedora:
+      distros:
+        - fedora-26-x86_64
+        - fedora-25-x86_64
+      vendor: "Fedora Project"
+      authoritative_source_url: "some.url.fedoraproject.org"
+      distro_specific_help: "Some Fedora specific help"
+    centos:
+      distros:
+        - centos-6-x86_64
+        - centos-7-x86_64
+      vendor: "CentOS"
+      authoritative_source_url: "some.url.centos.org"
+      distro_specific_help: "Some CentOS specific help"
+  version:
+    "2.2":
+      version: 2.2
+    "2.4":
+      version: 2.4
+
+matrix:
+  include:
+    - distros:
+        - centos-7-x86_64
+        - fedora-26-x86_64
+      version: "2.4"
+
+  combination_extras:
+    - distros:
+        - fedora-26-x86_64
+      version: "2.4"
+      data:
+        name_label: "$FGC/$NAME"
+    - distros:
+        - centos-7-x86_64
+      version: "2.2"
+      data:
+        name_label: "centos/SW-2.2-centos7"

--- a/tests/multispec-include/test.exp
+++ b/tests/multispec-include/test.exp
@@ -1,0 +1,67 @@
+=== fedora-26-x86_64 ===
+
+FROM registry.fedoraproject.org/fedora:26
+
+LABEL MAINTAINER ...
+
+ENV NAME=mycontainer VERSION=0 RELEASE=1 ARCH=x86_64
+
+LABEL summary="A container that tells you how awesome it is." \
+      com.redhat.component="$NAME" \
+      NAME="$FGC/$NAME" \
+      version="$VERSION" \
+      release="$RELEASE.$DISTTAG" \
+      architecture="$ARCH" \
+      usage="docker run -p 9000:9000 mycontainer" \
+      help="Runs mycontainer, which listens on port 9000 and tells you how awesome it is. No dependencies." \
+      description="This is a simple container that just tells you how awesome it is. That's it." \
+      vendor="Fedora Project" \
+      org.fedoraproject.component="postfix" \
+      authoritative-source-url="some.url.fedoraproject.org" \
+      io.k8s.description="This is a simple container that just tells you how awesome it is. That's it." \
+      io.k8s.display-name="Awesome container with SW version " \
+      io.openshift.expose-services="9000:http" \
+      io.openshift.tags="some,tags"
+
+EXPOSE 9000
+
+# We don't actually use the "software_version" here, but we could,
+#  e.g. to install a module with that ncat version
+RUN dnf -y install nmap-ncat && \
+    dnf -y clean all --enablerepo='*'
+
+CMD ["/usr/bin/script.sh"]
+
+
+=== centos-7-x86_64 ===
+
+FROM registry.centos.org/centos:centos7
+
+LABEL MAINTAINER ...
+
+ENV NAME=mycontainer VERSION=0 RELEASE=1 ARCH=x86_64
+
+LABEL summary="A container that tells you how awesome it is." \
+      com.redhat.component="$NAME" \
+      version="$VERSION" \
+      release="$RELEASE.$DISTTAG" \
+      architecture="$ARCH" \
+      usage="docker run -p 9000:9000 mycontainer" \
+      help="Runs mycontainer, which listens on port 9000 and tells you how awesome it is. No dependencies." \
+      description="This is a simple container that just tells you how awesome it is. That's it." \
+      vendor="CentOS" \
+      org.fedoraproject.component="postfix" \
+      authoritative-source-url="some.url.centos.org" \
+      io.k8s.description="This is a simple container that just tells you how awesome it is. That's it." \
+      io.k8s.display-name="Awesome container with SW version " \
+      io.openshift.expose-services="9000:http" \
+      io.openshift.tags="some,tags"
+
+EXPOSE 9000
+
+# We don't actually use the "software_version" here, but we could,
+#  e.g. to install a module with that ncat version
+RUN yum -y install nmap-ncat && \
+    yum -y clean all --enablerepo='*'
+
+CMD ["/usr/bin/script.sh"]

--- a/tests/multispec-include/test.tpl
+++ b/tests/multispec-include/test.tpl
@@ -1,0 +1,33 @@
+FROM {{ config.docker.registry }}/{{ config.docker.from }}
+
+LABEL MAINTAINER ...
+
+ENV NAME=mycontainer VERSION=0 RELEASE=1 ARCH=x86_64
+
+LABEL summary="A container that tells you how awesome it is." \
+      com.redhat.component="$NAME" \
+      {% if spec.name_label %}
+      NAME="{{ spec.name_label }}" \
+      {% endif %}
+      version="$VERSION" \
+      release="$RELEASE.$DISTTAG" \
+      architecture="$ARCH" \
+      usage="docker run -p 9000:9000 mycontainer" \
+      help="Runs mycontainer, which listens on port 9000 and tells you how awesome it is. No dependencies." \
+      description="{{ spec.description }}" \
+      vendor="{{ spec.vendor }}" \
+      org.fedoraproject.component="postfix" \
+      authoritative-source-url="{{ spec.authoritative_source_url }}" \
+      io.k8s.description="{{ spec.description }}" \
+      io.k8s.display-name="Awesome container with SW version {{ spec.software_version }}" \
+      io.openshift.expose-services="9000:http" \
+      io.openshift.tags="some,tags"
+
+EXPOSE 9000
+
+# We don't actually use the "software_version" here, but we could,
+#  e.g. to install a module with that ncat version
+RUN {{ commands.pkginstaller.install(['nmap-ncat']) }} && \
+    {{ commands.pkginstaller.cleancache() }}
+
+CMD ["/usr/bin/script.sh"]

--- a/tests/multispec-include/test.yaml
+++ b/tests/multispec-include/test.yaml
@@ -1,0 +1,2 @@
+name: myawesomeimage
+description: "This is a simple container that just tells you how awesome it is. That's it."

--- a/tests/testsuite
+++ b/tests/testsuite
@@ -15,6 +15,7 @@ tests="
     macros-short
     minimal-dockerfile
     multispec
+    multispec-include
     non-ascii-chars
     pkginstaller
     no-spec

--- a/tests/unittests/fixtures/multispec/complex-include.yaml
+++ b/tests/unittests/fixtures/multispec/complex-include.yaml
@@ -1,0 +1,55 @@
+version: 1
+
+specs:
+  distroinfo:
+    fedora:
+      distros:
+        - fedora-26-x86_64
+        - fedora-25-x86_64
+      vendor: "Fedora Project"
+      authoritative_source_url: "some.url.fedoraproject.org"
+      distro_specific_help: "Some Fedora specific help"
+    centos:
+      distros:
+        - centos-7-x86_64
+      vendor: "CentOS"
+      authoritative_source_url: "some.url.centos.org"
+      distro_specific_help: "Some CentOS specific help"
+  version:
+    "2.2":
+      version: "2.2"
+    "2.4":
+      version: "2.4"
+  something_else:
+    foo:
+      spam: ham
+    bar:
+      spam: eggs
+    baz:
+      spam: beans
+
+matrix:
+  include:
+    - distros:
+        - fedora-26-x86_64
+      version: "2.2"
+      something_else: foo
+    - distros:
+      - fedora-25-x86_64
+      version: "2.4"
+      something_else: bar
+
+  combination_extras:
+    - distros:
+        - fedora-26-x86_64
+      version: "2.4"
+      data:
+        name_label: "$FGC/$NAME"
+        base_version: 1
+
+    - distros:
+        - centos-7-x86_64
+      version: "2.2"
+      data:
+        name_label: "centos/SW-2.2-centos7"
+

--- a/tests/unittests/fixtures/multispec/invalid-include-exclude.yaml
+++ b/tests/unittests/fixtures/multispec/invalid-include-exclude.yaml
@@ -1,0 +1,65 @@
+version: 1
+
+specs:
+  distroinfo:
+    fedora:
+      distros:
+        - fedora-26-x86_64
+        - fedora-25-x86_64
+      vendor: "Fedora Project"
+      authoritative_source_url: "some.url.fedoraproject.org"
+      distro_specific_help: "Some Fedora specific help"
+    centos:
+      distros:
+        - centos-7-x86_64
+      vendor: "CentOS"
+      authoritative_source_url: "some.url.centos.org"
+      distro_specific_help: "Some CentOS specific help"
+  version:
+    "2.2":
+      version: "2.2"
+    "2.4":
+      version: "2.4"
+  something_else:
+    foo:
+      spam: ham
+    bar:
+      spam: eggs
+    baz:
+      spam: beans
+
+matrix:
+  exclude:
+    - distros:
+        - fedora-26-x86_64
+      version: "2.2"
+      something_else: foo
+    - distros:
+      - fedora-25-x86_64
+      version: "2.4"
+      something_else: bar
+
+  include:
+    - distros:
+        - fedora-26-x86_64
+      version: "2.2"
+      something_else: foo
+    - distros:
+      - fedora-25-x86_64
+      version: "2.4"
+      something_else: bar
+
+  combination_extras:
+    - distros:
+        - fedora-26-x86_64
+      version: "2.4"
+      data:
+        name_label: "$FGC/$NAME"
+        base_version: 1
+
+    - distros:
+        - centos-7-x86_64
+      version: "2.2"
+      data:
+        name_label: "centos/SW-2.2-centos7"
+


### PR DESCRIPTION
This adds a possibility to use `include` in a multispec matrix which is useful when you have a lot of possible combinations but you are interested only in a few of them. In that case, `include` is also easier to maintain when you add a new version into the multispec.

I did a little bit of refactoring because the method `check_matrix_combinations` had multiple purposes – it returned True/False for all matrix combinations and a data structure for `combination_extras`.

And now:
* Function `is_in_matrix` returns True/False if a combination of the distro and all the selectors is found in matrix. It does not care about include/exclude, that's handled on `verify_selectors` level.
* Function `get_extras` is there only for `combination_extras` returning all structures for which distro and selectors combinations fit.

Having both `include` and `exclude` in a single matrix is prohibited.

Tests are adjusted and some of them are new for the new functionality.

Fixes: #128 