### PR TITLE
Exit code 2 for unallowed selectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 man
 MANIFEST
 docs/_build
+.coverage

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test-unit:
 # Note that flake8 reports both W503 and W504 ATM :-/ so ignore W503 for now,
 # which is what should be considered the right setup.
 test-lint:
-	flake8 distgen/ --ignore=W503
+	flake8 distgen/ --ignore=W503 --max-line-length 99
 
 # Check that testsuite in packaged sources work fine, too.
 test-sdist-check:

--- a/distgen/err.py
+++ b/distgen/err.py
@@ -2,6 +2,6 @@ import logging
 import sys
 
 
-def fatal(msg):
+def fatal(msg, exit_code=1):
     logging.fatal(msg)
-    sys.exit(1)
+    sys.exit(exit_code)

--- a/distgen/generator.py
+++ b/distgen/generator.py
@@ -279,7 +279,7 @@ class Generator(object):
             except yaml.YAMLError as exc:
                 fatal("Error in multispec file: {0}".format(exc))
             except MultispecError as exc:
-                fatal(str(exc))
+                fatal(str(exc), exc.exit_code)
 
         try:
             tpl = self.project.tplgen.get_template(template)

--- a/distgen/multispec.py
+++ b/distgen/multispec.py
@@ -13,8 +13,9 @@ DISTROINFO_GRP_DISTROS = 'distros'
 
 
 class MultispecError(Exception):
-    def __init__(self, cause):
+    def __init__(self, cause, exit_code=1):
         self.cause = cause
+        self.exit_code = exit_code
 
     def __str__(self):
         return self.cause
@@ -277,7 +278,7 @@ class Multispec(object):
         distro = self.distrofile2name(distrofile)
         allowed, reason = self.verify_selectors(selectors, distro)
         if not allowed:
-            raise MultispecError(reason)
+            raise MultispecError(reason, exit_code=2)
 
         parsed_selectors = self.parse_selectors(selectors)
         selected_data = {}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 pytest
 pytest-catchlog
-pytest-cov<2.6
+pytest-cov
 coverage
 flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 pytest
 pytest-catchlog
 pytest-cov<2.6

--- a/tests/unittests/test_error.py
+++ b/tests/unittests/test_error.py
@@ -10,3 +10,9 @@ class TestFatal(object):
             fatal('Message')
         assert caplog.record_tuples == [('root', logging.CRITICAL, 'Message')]
         assert e.value.code == 1
+
+    def test_fatal_custom_exit_code(self, capsys, caplog):
+        with pytest.raises(SystemExit) as e:
+            fatal('Message', exit_code=4)
+        assert caplog.record_tuples == [('root', logging.CRITICAL, 'Message')]
+        assert e.value.code == 4


### PR DESCRIPTION
We need that for example for container images where we run
distgen for all combinations of distros/versions and some of
those combinations might not be allowed or present in multispec.
In this specific case, we want to silence the output from distgen
so the log from the generator is not full of errors.

It's hard to tell which exit code is the best one for this. I think that if you have correct definitions in multispec and you request some invalid or unallowed selectors from distgen, it can be considered as misuse of CLI which usually uses exit code 2. But we can use whatever we want so feel free to voice your preference.

There are some other simple fixes I did during the implementation of the main change.

Related: https://github.com/sclorg/s2i-python-container/issues/594