### PR TITLE
ci: drop CI cron jobs

### DIFF
--- a/.github/workflows/push-copr-build.yml
+++ b/.github/workflows/push-copr-build.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  schedule:
-    # This always runs against the default branch.  Two runs per month.
-    - cron: '0 0 1,16 * *'
 
 jobs:
   build:


### PR DESCRIPTION
Upon the git repository inactivity, cron jobs are likely disabled by GitHub which probably also disables other triggers (pull_request, push).