### PR TITLE
add long description to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,16 @@ def get_requirements():
     with open('requirements.txt') as f:
         return f.read().splitlines()
 
+def get_long_description():
+    with open('README.md') as f:
+        return str([l for l in f.read().splitlines() if not l.startswith('[![')])
 
 setup(
     name='distgen',
     version=dg_version,
     description='Templating system/generator for distributions',
+    long_description=get_long_description(),
+    long_description_content_type='text/markdown',
     author='Pavel Raiskup (see AUTHORS)',
     author_email='praiskup@redhat.com',
     maintainer='Bohuslav Kabrda',


### PR DESCRIPTION
This description is sourced from README.md.
All the lines starting with '[![' are removed. These are used for displaying badges on github, but do not have guaranty to work elsewhere. For examples these badges are displayed incorrectly in pypi.org, see, e.g., here[1].


[1] https://pypi.org/project/pypet/0.4.1/

Related: https://github.com/devexp-db/distgen/issues/133