### PR TITLE
Show long description in setup.py in readable format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def get_requirements():
 
 def get_long_description():
     with open('README.md') as f:
-        return str([l for l in f.read().splitlines() if not l.startswith('[![')])
+        return "\n".join(l for l in f.read().splitlines() if not l.startswith('[!['))
 
 setup(
     name='distgen',


### PR DESCRIPTION
Seems like pypi description needs fix up:
https://pypi.org/project/distgen/

This PR introduces readable form of README.md for a long_description field in setup.py.