### PR TITLE
Add support for CentOS Stream 10.

### DIFF
--- a/distgen/distconf/centos-stream-10-x86_64.yaml
+++ b/distgen/distconf/centos-stream-10-x86_64.yaml
@@ -1,0 +1,16 @@
+extends: "lib/centos-stream.yaml"
+
+os:
+  name: CentOS Stream
+  version: 10
+  arch: x86_64
+
+macros:
+  libdir: $prefix/lib64
+  # systemd stuff
+  unitdir: /usr/lib/systemd/system
+  userunitdir: /usr/lib/systemd/user
+
+docker:
+  registry: quay.io/centos
+  from: centos:stream10-development


### PR DESCRIPTION
Add support for CentOS Stream 10.
Use stream10-development because stream10 still do not exists.

https://quay.io/repository/centos/centos?tab=tags

Closes: #141