### PR TITLE
Fix release type for github workflows, switch to new auth

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -8,8 +8,9 @@
 name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
+  workflow_dispatch:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build-n-publish:
@@ -31,6 +32,4 @@ jobs:
         # https://github.com/pypa/gh-action-pypi-publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          # secrets.PYPI_API_TOKEN is set to usercont-release-bot user token
-          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true


### PR DESCRIPTION
`workflow_dispatch:` allows us to start the workflow manually in case something fails.

Type `published` fires _only_ when actually publishing the release. `create` also fires when draft is created/saved, so when you upload files to the release, it will automatically save it as draft. For security reasons, GitHub doesn't start workflow when `create` event is fired, if it doesn't also publish the release at the same time.

This can seemingly work in some repositories where no additional files are uploaded when doing the release, but that's not the case here. 

https://docs.github.com/en/webhooks/webhook-events-and-payloads#release
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release

From GitHub docs:

> Note: Workflows are not triggered for the created, edited, or deleted activity types for draft releases. When you create your release through the GitHub browser UI, your release may automatically be saved as a draft.

PR also removes the password field as PyPi uses new auth methods.