### PR TITLE
Drop the dependency on six

### DIFF
--- a/bin/dg
+++ b/bin/dg
@@ -9,8 +9,6 @@ import shutil
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
-import six
-
 import logging
 logging.basicConfig(format='dg: %(levelname)-8s: %(message)s')
 
@@ -161,10 +159,7 @@ def print_multispec_combinations(args):
 
 def render_template(args):
     temp_filename = False
-    if six.PY2:
-        output = sys.stdout
-    else:
-        output = sys.stdout.buffer
+    output = sys.stdout.buffer
     try:
         if args.output:
             _, temp_filename = tempfile.mkstemp(prefix="distgen-")

--- a/distgen/config.py
+++ b/distgen/config.py
@@ -1,4 +1,3 @@
-import six
 import copy
 
 from distgen.err import fatal
@@ -11,7 +10,7 @@ def _merge_yaml(origin, override):
     itself, otherwise recurse down for each item.
     """
     if isinstance(origin, dict) and isinstance(override, dict):
-        for k, v in six.iteritems(override):
+        for k in override.keys():
             if k in origin:
                 origin[k] = _merge_yaml(origin[k], override[k])
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 distro
 jinja2
-six
 pyyaml
 setuptools

--- a/rpm/distgen.spec.dg
+++ b/rpm/distgen.spec.dg
@@ -24,7 +24,6 @@ BuildArch:  noarch
 Requires: %{pypkg}-jinja2
 Requires: %{pypkg}-distro
 Requires: %{meh_pypkg}PyYAML
-Requires: %{pypkg}-six
 
 BuildRequires: make
 BuildRequires: %{pypkg}-devel
@@ -37,7 +36,6 @@ BuildRequires: %{pypkg}-pytest-catchlog
 %endif
 BuildRequires: %{meh_pypkg}PyYAML
 BuildRequires: %{pypkg}-setuptools
-BuildRequires: %{pypkg}-six
 
 Source0: https://pypi.org/packages/source/d/%name/%name-%version.tar.gz
 

--- a/tests/unittests/test_generator.py
+++ b/tests/unittests/test_generator.py
@@ -1,7 +1,7 @@
+import io
 import os
 
 import pytest
-import six
 
 from distgen.commands import CommandsConfig
 from distgen.generator import Generator
@@ -63,7 +63,7 @@ class TestGenerator(object):
     def test_render(self, project, template, max_passes, result):
         # TODO: more test cases for rendering
         self.g.load_project(project)
-        out = six.BytesIO()
+        out = io.BytesIO()
         self.g.render(
             [os.path.join(project, 'common.yaml')],
             os.path.join(project, 'complex.yaml'),
@@ -75,6 +75,4 @@ class TestGenerator(object):
             max_passes=max_passes,
         )
 
-        if six.PY2:
-            result = result.decode('utf-8')
         assert out.getvalue() == result


### PR DESCRIPTION
This drops the compatibility with Python 2.7 which should be OK (EPEL 7 is EOL).